### PR TITLE
Fixed author domain verification

### DIFF
--- a/dkimstatus.php
+++ b/dkimstatus.php
@@ -88,8 +88,8 @@ class dkimstatus extends rcube_plugin
                         /* Verify if its an author's domain signature or a third party
                         */
 
-                        if(preg_match("/[@][a-zA-Z0-9]+([.][a-zA-Z0-9]+)?\.[a-zA-Z]{2,4}/", $p['headers']->from, $m)) {
-                            $authordomain = $m[0];
+                        if(preg_match("/[@]([a-zA-Z0-9]+([.][a-zA-Z0-9]+)?\.[a-zA-Z]{2,4})/", $p['headers']->from, $m)) {
+                            $authordomain = $m[1];
                             if(preg_match("/header\.(d|i|from)=(([a-zA-Z0-9]+[_\.\-]?)+)?($authordomain)/", $results)) {
                                 $image = 'authorsign.png';
                                 $alt = 'verifiedsender';


### PR DESCRIPTION
The regex used to extract the domain from the "from" header field was also capturing the "@" symbol, causing it to never match the domain in the dkim header. This commit fixes this issue.
