### PR TITLE
Fixed authordomain matching

### DIFF
--- a/dkimstatus.php
+++ b/dkimstatus.php
@@ -105,7 +105,7 @@ class dkimstatus extends rcube_plugin
 
                         if(preg_match("/[@]([a-zA-Z0-9]+([.][a-zA-Z0-9]+)?\.[a-zA-Z]{2,4})/", $p['headers']->from, $m)) {
                             $authordomain = $m[1];
-                            if(preg_match("/header\.(d|i|from)=(([a-zA-Z0-9]+[_\.\-]?)+)?($authordomain)/", $results)) {
+                            if(preg_match("/header\.((d|i)|from)=(([a-zA-Z0-9]+[_\.\-]?)+)?(?(2)@|)($authordomain)/", $results)) {
                                 $image = 'authorsign.png';
                                 $alt = 'verifiedsender';
                                 $title = $results;


### PR DESCRIPTION
Fixed authordomain matching because of bug introducted by pull request #6. There is a difference in how the header.i|d and the header.from from the Authentication-Results header should be treated. See https://tools.ietf.org/html/rfc5451#page-23

The new regex matches both header.i=@test.com as header.from=test.com
